### PR TITLE
Fail open if Redis is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Performance tests can be run in the "profile" environment for more consistent re
 RAILS_ENV=profile rake test:performance
 ```
 
+## Resiliency
+
+If Redis is down (or raises any instance of Redis::BaseConnectionError), Mission Control Web middleware will fail-open.
+
+It's recommended to also consider using a resilient Redis client with a circuit-breaker. See [Semian](https://github.com/Shopify/semian).
+
 ## Contributing
 Contribution directions go here.
 

--- a/lib/mission_control/web/routes_cache.rb
+++ b/lib/mission_control/web/routes_cache.rb
@@ -27,6 +27,8 @@ class MissionControl::Web::RoutesCache
         # Using Redis client rather than Kredis as request interception with a middleware is performance-critical.
         MissionControl::Web.redis.smembers REDIS_KEY
       end
+    rescue Redis::BaseConnectionError
+      []
     end
 
     def memoize(ttl:)

--- a/test/mission_control/web/routes_cache_test.rb
+++ b/test/mission_control/web/routes_cache_test.rb
@@ -40,6 +40,12 @@ class MissionControl::Web::RoutesCacheTest < ActiveSupport::TestCase
 
     assert_equal 2, fake_redis.smembers_call_count
   end
+
+  test "fails open when Redis is down" do
+    MissionControl::Web.configuration.redis = FakeRedisDown.new
+
+    assert_not @routes.disabled?("/posts/123")
+  end
 end
 
 class FakeRedisWithCallCounter
@@ -48,6 +54,14 @@ class FakeRedisWithCallCounter
   def smembers(key)
     self.smembers_call_count += 1
     []
+  end
+
+  def flushdb; end
+end
+
+class FakeRedisDown
+  def smembers(key)
+    raise Redis::ConnectionError
   end
 
   def flushdb; end


### PR DESCRIPTION
https://3.basecamp.com/2914079/buckets/28546948/todos/5249636645

If there's a Redis connection problem, we will fail open.

This is compatible with [Semian](https://github.com/Shopify/semian#adapters):

> Semian works by intercepting resource access. Every time access is requested, Semian is queried, and it will raise an exception if the resource is unavailable according to the circuit breaker or bulkheads. This is done by monkey-patching the resource driver. The exception raised by the driver always inherits from the Base exception class of the driver, meaning you can always simply rescue the base class and catch both Semian and driver errors in the same rescue for fallbacks.

My understanding is that if the middleware host app (such as BC3) passes in a Redis client patched with Semian, the Semian circuit breaker pattern will apply also to MC-W. If not, we will still fail open but only after network timeouts etc.