### PR TITLE
Allow customizing parent application controller

### DIFF
--- a/app/controllers/mission_control/web/application_controller.rb
+++ b/app/controllers/mission_control/web/application_controller.rb
@@ -1,4 +1,4 @@
-class MissionControl::Web::ApplicationController < ActionController::Base
+class MissionControl::Web::ApplicationController < MissionControl::Web.configuration.base_controller_class.constantize
   default_form_builder MissionControl::Web::BulmaFormBuilder
   helper MissionControl::Web::ApplicationsHelper
 end

--- a/lib/mission_control/web/configuration.rb
+++ b/lib/mission_control/web/configuration.rb
@@ -3,6 +3,7 @@ class MissionControl::Web::Configuration
 
   attribute :enabled,               :boolean, default: true
   attribute :routes_cache_ttl,      :integer, default: 10.seconds
+  attribute :base_controller_class, :string,  default: "::ApplicationController"
 
   attr_writer :redis, :administered_applications
 

--- a/test/mission_control/web/base_application_controller_test.rb
+++ b/test/mission_control/web/base_application_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MissionControl::Web::BaseApplicationControllerTest < ActiveSupport::TestCase
+  test "engine's ApplicationController inherits from host's ApplicationController by default" do
+    assert MissionControl::Web::ApplicationController < ApplicationController
+  end
+end


### PR DESCRIPTION
https://3.basecamp.com/2914079/buckets/28546948/todos/5296448908

This is intended to use built-in authentication in the host app.

Shamelessly copied from https://github.com/basecamp/mission_control-jobs/pull/8, thanks @jorgemanrubia :)