### PR TITLE
Update regex pattern documentation for denied paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ Denied paths are cached by the middleware and refreshed from Redis on this inter
 ```rb
 config.mission_control.web.routes_cache_ttl = 10.seconds
 ```
+## Example Regex Patterns for Paths
+
+When configuring denied paths through the Mission Control - Web admin interface, you can use regex patterns to match Rails routes.
+
+1. **Deny all routes under a specific namespace (e.g., admin):**
+   ```plaintext
+   ^/admin/.*
+   ```
+   This pattern blocks access to all routes that start with `/admin/`.
+
+2. **Deny specific controller actions (e.g., editing user profiles or settings updates):**
+   ```plaintext
+   ^/users/edit
+   ^/settings/update
+   ```
+   These patterns ensure that routes like `/users/edit` and `/settings/update` are blocked.
+
+3. **Deny access to API routes under a specific version (e.g., API v1):**
+   ```plaintext
+   ^/api/v1/.*
+   ```
+   This pattern blocks all routes starting with `/api/v1/`, useful for deprecating old API versions.
 
 ## Testing
 


### PR DESCRIPTION
## Improve Documentation for Regex Patterns in 'Mission Control - Web'

This pull request updates the documentation related to regex patterns used for blocking specific routes in 'Mission Control - Web'. The enhancements include:

- **Detailed Regex Examples:** The regex patterns are now more detailed, covering use cases such as blocking entire namespaces (e.g., `/admin/.*`), specific controller actions (e.g., `/users/edit`), and API routes under a specific version (e.g., `/api/v1/.*`). These examples provide clear guidance on how to effectively configure the middleware to deny access to unwanted paths.

https://github.com/basecamp/mission_control-web/issues/41#issue-2287438465