### PR TITLE
Use the cdn version

### DIFF
--- a/app/views/layouts/mission_control/web/application.html.erb
+++ b/app/views/layouts/mission_control/web/application.html.erb
@@ -5,7 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.4/css/bulma.min.css" integrity="sha512-HqxHUkJM0SYcbvxUw5P60SzdOTy/QVwA1JJrvaXJv4q7lmbDZCmZaqz01UPOaQveoxfYRv1tHozWGPMcuTBuvQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <%= stylesheet_link_tag "mission_control/web/application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/layouts/mission_control/web/application.html.erb
+++ b/app/views/layouts/mission_control/web/application.html.erb
@@ -5,6 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">
     <%= stylesheet_link_tag "mission_control/web/application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>


### PR DESCRIPTION
Please use the CDN version. in rails 8 using propshaft this don't work:

```
 *= require_tree .
 *= require_self
```