### PR TITLE
Explicitly require redis in initializers/mission_control_web.rb

### DIFF
--- a/lib/generators/mission_control/web/install/admin_generator.rb
+++ b/lib/generators/mission_control/web/install/admin_generator.rb
@@ -4,6 +4,8 @@ module MissionControl::Web::Install
 
     def create_initializer_file
       create_file INITIALIZER_FILE_PATH, <<~RUBY, skip: true
+        require "redis"
+
         Rails.application.configure do
         end
       RUBY

--- a/lib/generators/mission_control/web/install/middleware_generator.rb
+++ b/lib/generators/mission_control/web/install/middleware_generator.rb
@@ -4,6 +4,8 @@ module MissionControl::Web::Install
 
     def create_initializer_file
       create_file INITIALIZER_FILE_PATH, <<~RUBY, skip: true
+        require "redis"
+  
         Rails.application.configure do
         end
       RUBY


### PR DESCRIPTION
While installing mission_control-web in a Rails app, if the said app doesn't already have "redis" in its Gemfile, then following error is encountered:

<img width="918" alt="Screenshot 2025-04-26 at 10 44 18 PM" src="https://github.com/user-attachments/assets/4b003f9d-f936-49ac-aa08-1eb53e967389" />


This PR requires "redis" explicitly in the `config/initializers/mission_control_web.rb` file to fix the above issue.
