### PR TITLE
Show dropdown of protected app's paths for easy selection.

### DIFF
--- a/app/controllers/mission_control/web/routes_controller.rb
+++ b/app/controllers/mission_control/web/routes_controller.rb
@@ -2,6 +2,7 @@ class MissionControl::Web::RoutesController < MissionControl::Web::ApplicationCo
   include MissionControl::Web::ApplicationScoped
 
   before_action :set_route, only: %i[ show edit update destroy ]
+  before_action :set_protected_app_paths, only: %i[ new edit ]
 
   def index
     @routes = @application.routes
@@ -46,7 +47,11 @@ class MissionControl::Web::RoutesController < MissionControl::Web::ApplicationCo
       @route = @application.routes.find(params[:id])
     end
 
+    def set_protected_app_paths
+      @protected_app_paths = @application.protected_app_paths
+    end
+
     def route_params
-      params.require(:route).permit(:name, :pattern, :enabled)
+      params.require(:route).permit(:name, :pattern, :enabled, :app_path)
     end
 end

--- a/app/models/mission_control/web/application/routes.rb
+++ b/app/models/mission_control/web/application/routes.rb
@@ -1,6 +1,10 @@
 module MissionControl::Web::Application::Routes
   extend ActiveSupport::Concern
 
+  included do
+    delegate :protected_app_paths, :set_protected_app_paths, to: :routes_cache
+  end
+
   def routes
     MissionControl::Web::Route.where(application_id: id)
   end

--- a/app/views/mission_control/web/routes/_form.html.erb
+++ b/app/views/mission_control/web/routes/_form.html.erb
@@ -7,8 +7,21 @@
   </div>
 
   <div class="field">
+    <%= form.label :app_path_select, "Application Path" %><br>
+    <%= form.select :app_path,
+        options_for_select([["None", nil]] + @protected_app_paths.map { |path, pattern| [path, path] }, route.app_path),
+        {},
+        { class: "select", id: "app_path_select", data: { patterns: @protected_app_paths.to_json } }
+    %>
+  </div>
+
+  <div class="field">
     <%= form.label :pattern %>
-    <%= form.text_field :pattern %>
+    <%= form.text_field :pattern, 
+        id: "pattern_field",
+        readonly: route.app_path.present?,
+        class: "input #{route.app_path.present? ? 'is-static' : ''}" %>
+    <p class="help">Pattern is set automatically based on the selected application path. If None is selected, you can enter a custom pattern.</p>
   </div>
 
   <div class="field">
@@ -24,3 +37,27 @@
     <% end %>
   </div>
 <% end %>
+
+<script>
+  document.getElementById('app_path_select').addEventListener('change', function(event) {
+    const select = event.target;
+    const selectedPath = select.value;
+    const patterns = JSON.parse(select.dataset.patterns);
+    const patternField = document.getElementById('pattern_field');
+    
+    if (selectedPath === null || selectedPath === "") {
+      // None selected
+      patternField.value = "";
+      patternField.readOnly = false;
+      patternField.classList.remove('is-static');
+    } else {
+      // App path selected
+      const pattern = patterns[selectedPath];
+      if (pattern) {
+        patternField.value = pattern;
+        patternField.readOnly = true;
+        patternField.classList.add('is-static');
+      }
+    }
+  });
+</script>

--- a/app/views/mission_control/web/routes/_route.html.erb
+++ b/app/views/mission_control/web/routes/_route.html.erb
@@ -4,6 +4,10 @@
   </td>
 
   <td>
+    <%= route.app_path.present? ? route.app_path : "None" %>
+  </td>
+
+  <td>
     <%= route.pattern %>
   </td>
 

--- a/app/views/mission_control/web/routes/index.html.erb
+++ b/app/views/mission_control/web/routes/index.html.erb
@@ -13,6 +13,7 @@
       <thead>
         <tr>
           <th>Name</th>
+          <th>Application Path</th>
           <th>Pattern</th>
           <th>Traffic Status</th>
         </tr>

--- a/app/views/mission_control/web/routes/show.html.erb
+++ b/app/views/mission_control/web/routes/show.html.erb
@@ -17,6 +17,15 @@
 
   <div class="columns">
     <div class="column is-one-fifth">
+      <p class="has-text-weight-semibold">Application Path</p>
+    </div>
+    <div class="column">
+      <p><%= @route.app_path.present? ? @route.app_path : "None" %></p>
+    </div>
+  </div>
+
+  <div class="columns">
+    <div class="column is-one-fifth">
       <p class="has-text-weight-semibold">Pattern</p>
     </div>
     <div class="column">

--- a/db/migrate/20221025093008_create_mission_control_web_routes.rb
+++ b/db/migrate/20221025093008_create_mission_control_web_routes.rb
@@ -5,6 +5,7 @@ class CreateMissionControlWebRoutes < ActiveRecord::Migration[7.0]
       t.string :pattern, null: false
       t.boolean :enabled, default: true
       t.string :application_id, null: false, index: true
+      t.string :app_path
 
       t.timestamps
     end

--- a/db/migrate/20250427140958_add_app_path_to_mission_control_web_routes.rb
+++ b/db/migrate/20250427140958_add_app_path_to_mission_control_web_routes.rb
@@ -1,0 +1,5 @@
+class AddAppPathToMissionControlWebRoutes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :mission_control_web_routes, :app_path, :string
+  end
+end

--- a/db/migrate/20250427140958_add_app_path_to_mission_control_web_routes.rb
+++ b/db/migrate/20250427140958_add_app_path_to_mission_control_web_routes.rb
@@ -1,5 +1,0 @@
-class AddAppPathToMissionControlWebRoutes < ActiveRecord::Migration[7.0]
-  def change
-    add_column :mission_control_web_routes, :app_path, :string
-  end
-end

--- a/lib/mission_control/web/engine.rb
+++ b/lib/mission_control/web/engine.rb
@@ -46,7 +46,6 @@ module MissionControl
           MissionControl::Web.host_application.set_protected_app_paths
         end
       end
-
     end
   end
 end

--- a/lib/mission_control/web/engine.rb
+++ b/lib/mission_control/web/engine.rb
@@ -40,6 +40,13 @@ module MissionControl
       config.after_initialize do
         MissionControl::Web.configuration.host_application_name ||= ::Rails.application.class.module_parent.to_s
       end
+
+      config.after_routes_loaded do
+        if MissionControl::Web.configuration.middleware_enabled?
+          MissionControl::Web.host_application.set_protected_app_paths
+        end
+      end
+
     end
   end
 end

--- a/lib/mission_control/web/routes_cache.rb
+++ b/lib/mission_control/web/routes_cache.rb
@@ -21,6 +21,16 @@ class MissionControl::Web::RoutesCache
     all_disabled_patterns.any? { |pattern| Regexp.new(pattern) =~ path }
   end
 
+  def set_protected_app_paths
+    redis.del protected_app_paths_redis_key
+
+    redis.hmset protected_app_paths_redis_key, build_protected_app_path_hash
+  end
+
+  def protected_app_paths
+    redis.hgetall protected_app_paths_redis_key
+  end
+
   private
     attr_reader :application
 
@@ -30,6 +40,10 @@ class MissionControl::Web::RoutesCache
 
     def redis_key
       :"mission_control_web_#{application.id}_disabled_patterns"
+    end
+
+    def protected_app_paths_redis_key
+      "mission_control_web_#{application.id}_protected_app_paths"
     end
 
     def all_disabled_patterns
@@ -48,5 +62,15 @@ class MissionControl::Web::RoutesCache
         @patterns_expires_at = Time.now + ttl
         @patterns = yield
       end
+    end
+
+    def build_protected_app_path_hash
+      routes_hash = {}
+      Rails.application.routes.routes.each do |route|
+        path_spec = route.path.spec.to_s
+        regexp_string = route.path.to_regexp.to_s
+        routes_hash[path_spec] = regexp_string
+      end
+      routes_hash.to_a.uniq(&:first).to_h
     end
 end

--- a/lib/mission_control/web/routes_cache.rb
+++ b/lib/mission_control/web/routes_cache.rb
@@ -29,6 +29,8 @@ class MissionControl::Web::RoutesCache
 
   def protected_app_paths
     redis.hgetall protected_app_paths_redis_key
+  rescue Redis::BaseConnectionError
+    {}
   end
 
   private

--- a/test/controllers/mission_control/web/routes_controller_test.rb
+++ b/test/controllers/mission_control/web/routes_controller_test.rb
@@ -29,13 +29,13 @@ class MissionControl::Web::RoutesControllerTest < ActionDispatch::IntegrationTes
 
   test "should create route with app_path" do
     assert_difference("MissionControl::Web::Route.count") do
-      post application_routes_url(@route.application), params: { 
-        route: { 
-          enabled: @route.enabled, 
-          name: @route.name, 
+      post application_routes_url(@route.application), params: {
+        route: {
+          enabled: @route.enabled,
+          name: @route.name,
           app_path: "/posts",
-          pattern: "^/posts$" 
-        } 
+          pattern: "^/posts$"
+        }
       }
     end
 
@@ -46,13 +46,13 @@ class MissionControl::Web::RoutesControllerTest < ActionDispatch::IntegrationTes
 
   test "should create route with custom pattern when no app_path selected" do
     assert_difference("MissionControl::Web::Route.count") do
-      post application_routes_url(@route.application), params: { 
-        route: { 
-          enabled: @route.enabled, 
-          name: @route.name, 
+      post application_routes_url(@route.application), params: {
+        route: {
+          enabled: @route.enabled,
+          name: @route.name,
           app_path: nil,
-          pattern: "/custom/pattern" 
-        } 
+          pattern: "/custom/pattern"
+        }
       }
     end
 
@@ -73,13 +73,13 @@ class MissionControl::Web::RoutesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should update route with app_path" do
-    patch application_route_url(@route.application, @route), params: { 
-      route: { 
-        enabled: @route.enabled, 
-        name: @route.name, 
+    patch application_route_url(@route.application, @route), params: {
+      route: {
+        enabled: @route.enabled,
+        name: @route.name,
         app_path: "/posts",
-        pattern: "^/posts$" 
-      } 
+        pattern: "^/posts$"
+      }
     }
     assert_redirected_to application_route_url(@route.application, @route)
     @route.reload
@@ -88,13 +88,13 @@ class MissionControl::Web::RoutesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should update route with custom pattern when no app_path selected" do
-    patch application_route_url(@route.application, @route), params: { 
-      route: { 
-        enabled: @route.enabled, 
-        name: @route.name, 
+    patch application_route_url(@route.application, @route), params: {
+      route: {
+        enabled: @route.enabled,
+        name: @route.name,
         app_path: nil,
-        pattern: "/custom/pattern" 
-      } 
+        pattern: "/custom/pattern"
+      }
     }
     assert_redirected_to application_route_url(@route.application, @route)
     @route.reload

--- a/test/controllers/mission_control/web/routes_controller_test.rb
+++ b/test/controllers/mission_control/web/routes_controller_test.rb
@@ -5,6 +5,8 @@ class MissionControl::Web::RoutesControllerTest < ActionDispatch::IntegrationTes
 
   setup do
     @route = mission_control_web_routes(:posts)
+    @protected_app_paths = { "/posts" => "^/posts$" }
+    MissionControl::Web::RoutesCache.any_instance.stubs(:protected_app_paths).returns(@protected_app_paths)
   end
 
   test "should get index" do
@@ -22,14 +24,41 @@ class MissionControl::Web::RoutesControllerTest < ActionDispatch::IntegrationTes
   test "should get new" do
     get new_application_route_url(@route.application)
     assert_response :success
+    assert_select "select#app_path_select"
   end
 
-  test "should create route" do
+  test "should create route with app_path" do
     assert_difference("MissionControl::Web::Route.count") do
-      post application_routes_url(@route.application), params: { route: { enabled: @route.enabled, name: @route.name, pattern: "/posts/123" } }
+      post application_routes_url(@route.application), params: { 
+        route: { 
+          enabled: @route.enabled, 
+          name: @route.name, 
+          app_path: "/posts",
+          pattern: "^/posts$" 
+        } 
+      }
     end
 
     assert_redirected_to application_route_url(@route.application, MissionControl::Web::Route.last)
+    assert_equal "/posts", MissionControl::Web::Route.last.app_path
+    assert_equal "^/posts$", MissionControl::Web::Route.last.pattern
+  end
+
+  test "should create route with custom pattern when no app_path selected" do
+    assert_difference("MissionControl::Web::Route.count") do
+      post application_routes_url(@route.application), params: { 
+        route: { 
+          enabled: @route.enabled, 
+          name: @route.name, 
+          app_path: nil,
+          pattern: "/custom/pattern" 
+        } 
+      }
+    end
+
+    assert_redirected_to application_route_url(@route.application, MissionControl::Web::Route.last)
+    assert_nil MissionControl::Web::Route.last.app_path
+    assert_equal "/custom/pattern", MissionControl::Web::Route.last.pattern
   end
 
   test "should show route" do
@@ -40,11 +69,37 @@ class MissionControl::Web::RoutesControllerTest < ActionDispatch::IntegrationTes
   test "should get edit" do
     get edit_application_route_url(@route.application, @route)
     assert_response :success
+    assert_select "select#app_path_select"
   end
 
-  test "should update route" do
-    patch application_route_url(@route.application, @route), params: { route: { enabled: @route.enabled, name: @route.name, pattern: @route.pattern } }
+  test "should update route with app_path" do
+    patch application_route_url(@route.application, @route), params: { 
+      route: { 
+        enabled: @route.enabled, 
+        name: @route.name, 
+        app_path: "/posts",
+        pattern: "^/posts$" 
+      } 
+    }
     assert_redirected_to application_route_url(@route.application, @route)
+    @route.reload
+    assert_equal "/posts", @route.app_path
+    assert_equal "^/posts$", @route.pattern
+  end
+
+  test "should update route with custom pattern when no app_path selected" do
+    patch application_route_url(@route.application, @route), params: { 
+      route: { 
+        enabled: @route.enabled, 
+        name: @route.name, 
+        app_path: nil,
+        pattern: "/custom/pattern" 
+      } 
+    }
+    assert_redirected_to application_route_url(@route.application, @route)
+    @route.reload
+    assert_nil @route.app_path
+    assert_equal "/custom/pattern", @route.pattern
   end
 
   test "should destroy route" do

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema[7.1].define(version: 2022_10_25_093008) do
     t.string "pattern", null: false
     t.boolean "enabled", default: true
     t.string "application_id", null: false
+    t.string "app_path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["application_id", "pattern"], name: "index_mission_control_web_routes_on_application_id_and_pattern", unique: true

--- a/test/mission_control/web/routes_cache_test.rb
+++ b/test/mission_control/web/routes_cache_test.rb
@@ -67,7 +67,7 @@ class MissionControl::Web::RoutesCacheTest < ActiveSupport::TestCase
     assert_equal 1, fake_redis.del_call_count
     assert_equal 1, fake_redis.hmset_call_count
     assert_equal "mission_control_web_dummy-app_protected_app_paths", fake_redis.last_hmset_key
-    assert_equal [{"/posts"=> "^/posts$"}], fake_redis.last_hmset_values
+    assert_equal [ { "/posts"=> "^/posts$" } ], fake_redis.last_hmset_values
   end
 
   test "protected_app_paths retrieves routes from Redis" do

--- a/test/mission_control/web/routes_cache_test.rb
+++ b/test/mission_control/web/routes_cache_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "ostruct"
 
 class MissionControl::Web::RoutesCacheTest < ActiveSupport::TestCase
   setup do
@@ -51,14 +52,66 @@ class MissionControl::Web::RoutesCacheTest < ActiveSupport::TestCase
 
     assert_not @routes.disabled?("/posts/123")
   end
+
+  test "set_protected_app_paths stores routes in Redis" do
+    MissionControl::Web.configuration.redis = fake_redis = FakeRedisWithCallCounter.new
+    Rails.application.routes.routes.stubs(:each).yields(
+      OpenStruct.new(path: OpenStruct.new(
+        spec: OpenStruct.new(to_s: "/posts"),
+        to_regexp: OpenStruct.new(to_s: "^/posts$")
+      ))
+    )
+
+    @routes.set_protected_app_paths
+
+    assert_equal 1, fake_redis.del_call_count
+    assert_equal 1, fake_redis.hmset_call_count
+    assert_equal "mission_control_web_dummy-app_protected_app_paths", fake_redis.last_hmset_key
+    assert_equal [{"/posts"=> "^/posts$"}], fake_redis.last_hmset_values
+  end
+
+  test "protected_app_paths retrieves routes from Redis" do
+    MissionControl::Web.configuration.redis = fake_redis = FakeRedisWithCallCounter.new
+
+    @routes.protected_app_paths
+
+    assert_equal 1, fake_redis.hgetall_call_count
+  end
+
+  test "protected_app_paths returns empty hash when Redis is down" do
+    MissionControl::Web.configuration.redis = FakeRedisDown.new
+
+    result = @routes.protected_app_paths
+
+    assert_equal({}, result)
+  end
 end
 
 class FakeRedisWithCallCounter
   class_attribute :smembers_call_count, default: 0
+  class_attribute :del_call_count, default: 0
+  class_attribute :hmset_call_count, default: 0
+  class_attribute :hgetall_call_count, default: 0
+  attr_accessor :last_hmset_key, :last_hmset_values
 
   def smembers(key)
     self.smembers_call_count += 1
     []
+  end
+
+  def del(key)
+    self.del_call_count += 1
+  end
+
+  def hmset(key, *values)
+    self.hmset_call_count += 1
+    self.last_hmset_key = key
+    self.last_hmset_values = values
+  end
+
+  def hgetall(key)
+    self.hgetall_call_count += 1
+    {}
   end
 
   def flushdb; end
@@ -66,6 +119,18 @@ end
 
 class FakeRedisDown
   def smembers(key)
+    raise Redis::ConnectionError
+  end
+
+  def del(key)
+    raise Redis::ConnectionError
+  end
+
+  def hmset(key, *values)
+    raise Redis::ConnectionError
+  end
+
+  def hgetall(key)
     raise Redis::ConnectionError
   end
 


### PR DESCRIPTION
This PR introduces an option to pick paths for denying traffic from the protected app's available routes. Implements #39

**Approach**
After routes are loaded in the Protected app, it writes its available routes to the shared Redis instance. The Admin app reads the available routes for an application from the same shared Redis instance.

Users can still enter custom patterns by selecting `None` in Application Path field.

Note: 

1. I didn't use `stimulus` for the small JS script, as I wanted to avoid adding `stimulus-rails` dependency.

<img width="1419" alt="Create new route" src="https://github.com/user-attachments/assets/597eef60-90a0-4852-b5aa-5409c75edb68" />

<img width="1524" alt="Index" src="https://github.com/user-attachments/assets/294ae25e-4e80-4b48-8b34-a49cbc0c6c50" />
